### PR TITLE
Allow aliases for piece names

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,8 @@ module.exports = {
         ],
         'quotes': [
             'error',
-            'single'
+            'single',
+            { 'avoidEscape': true }
         ],
         'semi': [
             'error',

--- a/README.md
+++ b/README.md
@@ -31,6 +31,36 @@ to algebraic notation. For example, "bishop takes a8" becomes "Bxa8".
     const parser = new ChessNLP();
     console.log(parser.toSAN('castle queenside')); // O-O-O
 
+## Configuration
+
+The parser can be configured to accept alternate spellings of piece names. For
+example:
+
+    const options = {
+        aliases: {
+            knight: ['horse', 'jumper'],
+            rook: ['tower']
+        }
+    };
+    const parser = new ChessNLP(options);
+
+    parser.toSAN('Horse to F6'); // Nf6
+    parser.toSAN('tower takes b2 checkmate'); // Rxb2#
+
+The aliases object can contain one or more of the following keys:
+
+* king
+* queen
+* rook
+* bishop
+* knight
+
+## Exceptions
+
+The parser will throw an exception if the supplied text cannot be parsed:
+
+    parser.toSAN('foo'); // Invalid move: foo
+
 ## Examples
 
     bishop to D7                    -> Bd7

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-nlp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Convert natural language descriptions of chess moves to algebraic notation",
   "main": "dist/chess-nlp.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -172,7 +172,16 @@ const parser = peg.generate(grammar);
 export default class ChessNLP {
 
     toSAN(text) {
-        return parser.parse(text);
+        try {
+            return parser.parse(text);
+        }
+        catch (error) {
+            if (error.name === 'SyntaxError') {
+                throw new Error(`Invalid move: ${text}`);
+            }
+
+            throw error;
+        }
     }
 
 }

--- a/src/index.js
+++ b/src/index.js
@@ -148,27 +148,27 @@ const configurableRules = {
     king: {
         name: 'king',
         defaultTerm: 'king',
-        action: `return 'K';`
+        action: "return 'K';"
     },
     queen: {
         name: 'queen',
         defaultTerm: 'queen',
-        action: `return 'Q';`
+        action: "return 'Q';"
     },
     rook: {
         name: 'rook',
         defaultTerm: 'rook',
-        action: `return 'R';`
+        action: "return 'R';"
     },
     bishop: {
         name: 'bishop',
         defaultTerm: 'bishop',
-        action: `return 'B';`
+        action: "return 'B';"
     },
     knight: {
         name: 'knight',
         defaultTerm: 'knight',
-        action: `return 'N';`
+        action: "return 'N';"
     }
 };
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -40,6 +40,12 @@ describe('ChessNLP', function() {
                 .to.throw('Invalid en passant capture');
         });
 
+        it("should throw an error when text can't be parsed", function() {
+            const parser = new ChessNLP();
+
+            expect(() => parser.toSAN('foo')).to.throw('Invalid move: foo');
+        });
+
     });
 
 });

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -4,6 +4,20 @@ import ChessNLP from './index';
 
 describe('ChessNLP', function() {
 
+    describe('constructor', function() {
+
+        it('should succeed with no arguments', function() {
+            expect(() => new ChessNLP()).not.to.throw();
+        });
+
+        it('should accept an "aliases" option', function() {
+            const parser = new ChessNLP({ aliases: 'foo' });
+
+            expect(parser.aliases).to.equal('foo');
+        });
+
+    });
+
     describe('toSAN', function() {
 
         it.each([
@@ -44,6 +58,22 @@ describe('ChessNLP', function() {
             const parser = new ChessNLP();
 
             expect(() => parser.toSAN('foo')).to.throw('Invalid move: foo');
+        });
+
+    });
+
+    describe('aliases', function() {
+
+        it.each([
+            ['king', ['foo', 'bar'], 'bar takes c7', 'Kxc7'],
+            ['queen', ['kween'], 'KwEen to A8', 'Qa8'],
+            ['rook', ['Brooke', 'brook', 'hook'], 'brook A d6', 'Rad6'],
+            ['bishop', ['foo', 'bar'], 'foo 2 e4', 'B2e4'],
+            ['knight', ['night', 'nite'], 'Night captures b2 mate', 'Nxb2#'],
+        ])('%j aliases', (target, aliases, text, expected) => {
+            const parser = new ChessNLP({ aliases: { [target]: aliases } });
+
+            expect(parser.toSAN(text)).to.equal(expected);
         });
 
     });


### PR DESCRIPTION
Allow the user to supply aliases for piece names, e.g.

```
const options = {
    aliases: {
        knight: ['horse', 'jumper'],
        rook: ['tower']
    }
};
const parser = new ChessNLP(options);

parser.toSAN('Horse to F6'); // Nf6
parser.toSAN('tower takes b2 checkmate'); // Rxb2#
```