### PR TITLE
Add rank aliases and more flexible parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ to algebraic notation. For example, "bishop takes a8" becomes "Bxa8".
 
 ## Configuration
 
-The parser can be configured to accept alternate spellings of pieces and files.
-For example:
+The parser can be configured to accept alternate spellings of pieces, ranks,
+and files. For example:
 
     const options = {
         aliases: {
@@ -42,7 +42,10 @@ For example:
             rook: ['tower'],
             a: ['alpha'],
             b: ['beta', 'bravo'],
-            c: ['charlie']
+            c: ['charlie'],
+            1: ['i'],
+            2: ['ii'],
+            3: ['iii']
         }
     };
     const parser = new ChessNLP(options);
@@ -51,6 +54,24 @@ For example:
     parser.toSAN('tower takes b2 checkmate'); // Rxb2#
     parser.toSAN('tower alpha takes bravo7'); // Raxb7
     parser.toSAN('horse charlie to Alpha 4'); // Nca4
+    parser.toSAN('tower to betaIII');         // Rb3
+
+Note that when one alias is a substring of another, the longest alias must come
+first:
+
+    // This works
+    const options = {
+        aliases: {
+            2: ['tooo', 'too', 'to']
+        }
+    };
+
+    // This doesn't
+    const options = {
+        aliases: {
+            2: ['to', 'too', 'tooo']
+        }
+    };
 
 The aliases object can contain the following keys:
 
@@ -67,6 +88,14 @@ The aliases object can contain the following keys:
 * f
 * g
 * h
+* 1
+* 2
+* 3
+* 4
+* 5
+* 6
+* 7
+* 8
 
 ## Exceptions
 
@@ -97,3 +126,4 @@ The parser will throw an exception if the supplied text cannot be parsed:
     castle Queenside                -> O-O-O
     Black Resigns                   -> 1-0
     white resigns                   -> 0-1
+    king to d seven                 -> Kd7

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-nlp",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Convert natural language descriptions of chess moves to algebraic notation",
   "main": "dist/chess-nlp.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -139,10 +139,10 @@ const grammar = `
           { return coordinates.join(''); }
 
     rank
-        = [1-8]
+        = rank_1 / rank_2 / rank_3 / rank_4 / rank_5 / rank_6 / rank_7 / rank_8
 
     file
-        = a / b / c / d / e / f / g / h
+        = file_a / file_b / file_c / file_d / file_e / file_f / file_g / file_h
 
     piece
         = king / queen / rook / bishop / knight
@@ -155,69 +155,110 @@ const configurableRules = {
     // Pieces
     king: {
         name: 'king',
-        defaultTerm: 'king',
+        defaultTerms: ['king'],
         action: "return 'K';"
     },
     queen: {
         name: 'queen',
-        defaultTerm: 'queen',
+        defaultTerms: ['queen'],
         action: "return 'Q';"
     },
     rook: {
         name: 'rook',
-        defaultTerm: 'rook',
+        defaultTerms: ['rook'],
         action: "return 'R';"
     },
     bishop: {
         name: 'bishop',
-        defaultTerm: 'bishop',
+        defaultTerms: ['bishop'],
         action: "return 'B';"
     },
     knight: {
         name: 'knight',
-        defaultTerm: 'knight',
+        defaultTerms: ['knight'],
         action: "return 'N';"
     },
     // Files
     a: {
-        name: 'a',
-        defaultTerm: 'a',
+        name: 'file_a',
+        defaultTerms: ['a'],
         action: "return 'a';"
     },
     b: {
-        name: 'b',
-        defaultTerm: 'b',
+        name: 'file_b',
+        defaultTerms: ['b'],
         action: "return 'b';"
     },
     c: {
-        name: 'c',
-        defaultTerm: 'c',
+        name: 'file_c',
+        defaultTerms: ['c'],
         action: "return 'c';"
     },
     d: {
-        name: 'd',
-        defaultTerm: 'd',
+        name: 'file_d',
+        defaultTerms: ['d'],
         action: "return 'd';"
     },
     e: {
-        name: 'e',
-        defaultTerm: 'e',
+        name: 'file_e',
+        defaultTerms: ['e'],
         action: "return 'e';"
     },
     f: {
-        name: 'f',
-        defaultTerm: 'f',
+        name: 'file_f',
+        defaultTerms: ['f'],
         action: "return 'f';"
     },
     g: {
-        name: 'g',
-        defaultTerm: 'g',
+        name: 'file_g',
+        defaultTerms: ['g'],
         action: "return 'g';"
     },
     h: {
-        name: 'h',
-        defaultTerm: 'h',
+        name: 'file_h',
+        defaultTerms: ['h'],
         action: "return 'h';"
+    },
+    // Ranks
+    1: {
+        name: 'rank_1',
+        defaultTerms: ['1', 'one'],
+        action: "return '1';"
+    },
+    2: {
+        name: 'rank_2',
+        defaultTerms: ['2', 'two'],
+        action: "return '2';"
+    },
+    3: {
+        name: 'rank_3',
+        defaultTerms: ['3', 'three'],
+        action: "return '3';"
+    },
+    4: {
+        name: 'rank_4',
+        defaultTerms: ['4', 'four'],
+        action: "return '4';"
+    },
+    5: {
+        name: 'rank_5',
+        defaultTerms: ['5', 'five'],
+        action: "return '5';"
+    },
+    6: {
+        name: 'rank_6',
+        defaultTerms: ['6', 'six'],
+        action: "return '6';"
+    },
+    7: {
+        name: 'rank_7',
+        defaultTerms: ['7', 'seven'],
+        action: "return '7';"
+    },
+    8: {
+        name: 'rank_8',
+        defaultTerms: ['8', 'eight'],
+        action: "return '8';"
     },
 };
 
@@ -227,7 +268,7 @@ const configurableRules = {
  */
 const generateRuleText = (rule, aliases) => {
     // Make all terms case insensitive
-    const terms = [...aliases, rule.defaultTerm].map(term => `'${term}'i`);
+    const terms = [...aliases, ...rule.defaultTerms].map(term => `'${term}'i`);
 
     return `${rule.name} = ( ${terms.join(' / ')} ) { ${rule.action} }\n`;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -103,8 +103,14 @@ const grammar = `
         = ('checkmate'i / 'mate'i) { return '#'; }
 
     castle
-        = 'castle'i whitespace side:('kingside'i / 'queenside'i)
+        = 'castle'i whitespace side:(kingside / queenside)
           { return /king/i.test(side) ? 'O-O' : 'O-O-O'; }
+
+    kingside
+        = 'king'i whitespace 'side'i / 'king-side'i / 'kingside'i
+
+    queenside
+        = 'queen'i whitespace 'side'i / 'queen-side'i / 'queenside'i
 
     resign
         = player:('black'i / 'white'i) whitespace 'resigns'i

--- a/src/index.js
+++ b/src/index.js
@@ -135,7 +135,11 @@ const grammar = `
         = square
 
     square
-        = coordinates:(file rank / file whitespace rank)
+        = coordinates:(
+              file rank /
+              file whitespace rank /
+              file:(file) '-' rank:(rank) { return [file, rank]; }
+          )
           { return coordinates.join(''); }
 
     rank

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -45,6 +45,14 @@ describe('ChessNLP', function() {
             ['white resigns', '0-1'],
             ['rook a takes a3', 'Raxa3'],
             ['queen c 2 d 3', 'Qc2d3'],
+            ['e one', 'e1'],
+            ['bishop captures A two', 'Bxa2'],
+            ['queen to b three check', 'Qb3+'],
+            ['knight take hfour checkmate', 'Nxh4#'],
+            ['Cfive', 'c5'],
+            ['f six', 'f6'],
+            ['king dseven', 'Kd7'],
+            ['rook six f eight', 'R6f8'],
         ])('.toSAN(%j)', (text, expected) => {
             const parser = new ChessNLP();
 
@@ -82,6 +90,14 @@ describe('ChessNLP', function() {
             ['f', ['foxtrot'], 'knight foxtrot 3', 'Nf3'],
             ['g', ['golf'], 'rook golf takes golf2', 'Rgxg2'],
             ['h', ['hotel', 'hey'], 'rook hey takes hotel 6', 'Rhxh6'],
+            ['1', ['i', 'won'], 'rook won takes a i', 'R1xa1'],
+            ['2', ['too', 'to'], 'e too', 'e2'],
+            ['3', ['iii'], 'knight to fiii', 'Nf3'],
+            ['4', ['force'], 'bishop g force', 'Bg4'],
+            ['5', ['v'], 'Knight V to b7', 'N5b7'],
+            ['6', ['vi'], 'hvi', 'h6'],
+            ['7', ['vii'], 'Queen to c vii check', 'Qc7+'],
+            ['8', ['ate'], 'king b ate', 'Kb8'],
         ])('%j aliases', (target, aliases, text, expected) => {
             const parser = new ChessNLP({ aliases: { [target]: aliases } });
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -39,6 +39,8 @@ describe('ChessNLP', function() {
             ['E7 check', 'e7+'],
             ['castle kingside', 'O-O'],
             ['castle Queenside', 'O-O-O'],
+            ['castle King Side', 'O-O'],
+            ['castle queen-side', 'O-O-O'],
             ['Black Resigns', '1-0'],
             ['white resigns', '0-1'],
             ['rook a takes a3', 'Raxa3'],

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -53,6 +53,7 @@ describe('ChessNLP', function() {
             ['f six', 'f6'],
             ['king dseven', 'Kd7'],
             ['rook six f eight', 'R6f8'],
+            ['queen a-4', 'Qa4'],
         ])('.toSAN(%j)', (text, expected) => {
             const parser = new ChessNLP();
 


### PR DESCRIPTION
Add:

* rank aliases
* allow spelled-out numbers (e.g. "eight") by default
* allow spaces and dashes in castling ("castle king side", "castle queen-side")
* allow dashes in squares (e.g. "king to g-6")