### PR TITLE
Allow aliases in any order

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,23 +56,6 @@ and files. For example:
     parser.toSAN('horse charlie to Alpha 4'); // Nca4
     parser.toSAN('tower to betaIII');         // Rb3
 
-Note that when one alias is a substring of another, the longest alias must come
-first:
-
-    // This works
-    const options = {
-        aliases: {
-            2: ['tooo', 'too', 'to']
-        }
-    };
-
-    // This doesn't
-    const options = {
-        aliases: {
-            2: ['to', 'too', 'tooo']
-        }
-    };
-
 The aliases object can contain the following keys:
 
 * king

--- a/src/index.js
+++ b/src/index.js
@@ -271,8 +271,12 @@ const configurableRules = {
  * be added to the parser grammar.
  */
 const generateRuleText = (rule, aliases) => {
-    // Make all terms case insensitive
-    const terms = [...aliases, ...rule.defaultTerms].map(term => `'${term}'i`);
+    // Sort terms by length, with longest terms first to avoid matching shorter
+    // terms that are substrings of longer ones, and make all matches case
+    // insensitive
+    const terms = [...rule.defaultTerms, ...aliases]
+        .sort((a, b) => b.length - a.length)
+        .map(term => `'${term}'i`);
 
     return `${rule.name} = ( ${terms.join(' / ')} ) { ${rule.action} }\n`;
 };

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -105,6 +105,12 @@ describe('ChessNLP', function() {
             expect(parser.toSAN(text)).to.equal(expected);
         });
 
+        it('should allow aliases in any order', () => {
+            const parser = new ChessNLP({ aliases: { 4: ['for', 'fore'] } });
+
+            expect(parser.toSAN('knight to h fore')).to.equal('Nh4');
+        });
+
     });
 
 });


### PR DESCRIPTION
Before, if one alias was a substring of another, they had to be ordered
with the longest first, e.g.

    aliases: { 4: ['fore', 'for'] }

Otherwise, the input string could contain the longer alias but the
parser would match it to the shorter alias, leaving extra unmatched
characters on the end. This commit allows the user to specify aliases in
any order.